### PR TITLE
Better legends

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Les données affichées sont mises à la disposition du public par la région Î
 L’observatoire est un site statique, réalisé avec [next.js](https://nextjs.org/). [Node](https://nodejs.org/en/download/package-manager) et [`yarn`](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable) sont requis.
 
 - Outre la génération du html, le projet récupère les données depuis cocarto et prépare le contenu à afficher pour chaque segment. Notamment, les données des communes sont rajoutées à partir de `./data/communes-ile-de-france.geo.json`.
-- La carte est réalisée avec maplibre, et utilise un fond de carte préparé sur maptiler.com. 
+- La carte est réalisée avec maplibre, et utilise un fond de carte préparé sur maptiler.com.
 
 Ces deux variables d’environnement sont nécessaires:
 
@@ -21,11 +21,13 @@ NEXT_PUBLIC_MAPBOX_TOKEN= # maptiler token
 ### Développement
 
 Installer les dépendances:
+
 ```
 yarn install
 ```
 
 Démarrer un serveur local:
+
 ```
 yarn dev
 ```
@@ -35,6 +37,7 @@ yarn dev
 ```
 yarn build
 ```
+
 génère un site statique dans le dossier `./out`.
 
-## 
+##

--- a/src/app/component/legend.tsx
+++ b/src/app/component/legend.tsx
@@ -1,5 +1,10 @@
 import { TronçonStatus, LengthStats } from "../types";
-import { statusColor, borderStatusColor, statusLabel, statusTooltip } from "@/utils/constants";
+import {
+  statusColor,
+  borderStatusColor,
+  statusLabel,
+  statusTooltip,
+} from "@/utils/constants";
 
 function LegendItem({
   stats,

--- a/src/app/component/legend.tsx
+++ b/src/app/component/legend.tsx
@@ -1,5 +1,5 @@
 import { TronçonStatus, LengthStats } from "../types";
-import { statusColor, statusLabel, statusTooltip } from "@/utils/constants";
+import { statusColor, borderStatusColor, statusLabel, statusTooltip } from "@/utils/constants";
 
 function LegendItem({
   stats,
@@ -13,7 +13,11 @@ function LegendItem({
   const style = {
     background: statusColor[status],
     border: "none",
+    outline: `solid 1px ${borderStatusColor[status]}`,
   };
+  if (status === TronçonStatus.Planned || status === TronçonStatus.Blocked) {
+    style.border = "solid 1px white";
+  }
   return (
     <div className="legend__item">
       <span className="legend__item-value">
@@ -29,7 +33,7 @@ function LegendItem({
 function SecondPhaseLegendItem() {
   const style = {
     background: statusColor[TronçonStatus.SecondPhase],
-    outline: "solid .5px #7f7f7f",
+    outline: "solid 1px #7f7f7f",
   };
 
   return (
@@ -45,9 +49,9 @@ function SecondPhaseLegendItem() {
 function VariantLegenditem() {
   const style = {
     background:
-      "repeating-linear-gradient(90deg, lightgray, lightgray 3px, white 3px, white 6px)",
-    border: "solid 1px white",
-    outline: "solid .5px #7f7f7f",
+      "repeating-linear-gradient(90deg, #BAB7B3, #BAB7B3 3px, white 3px, white 6px)",
+    border: "solid .5px white",
+    outline: "solid 1px #7f7f7f",
   };
 
   return (

--- a/src/app/component/legend.tsx
+++ b/src/app/component/legend.tsx
@@ -14,15 +14,10 @@ function LegendItem({
     background: statusColor[status],
     border: "none",
   };
-  if (status === TronçonStatus.SecondPhase) {
-    style.border = "solid 1px #7f7f7f";
-  }
   return (
     <div className="legend__item">
       <span className="legend__item-value">
-        {status !== TronçonStatus.SecondPhase
-          ? Math.round((100 * stats[status]) / total) + "%"
-          : ""}
+        {Math.round((100 * stats[status]) / total) + "%"}
       </span>
       <span style={style} className="legend__item-color" />
       <span>{statusLabel[status]}</span>

--- a/src/app/component/map.tsx
+++ b/src/app/component/map.tsx
@@ -14,7 +14,8 @@ import {
 import {
   baseLayer,
   exceptedVariants,
-  onlyVariants,
+  onlyDoneVariants,
+  onlyUpcomingVariants,
   colorFromStatus,
   showWhen,
   hideWhen,
@@ -125,8 +126,17 @@ export default function Map({ bounds, segments, level, setHash }: Props) {
             },
           })
           .addLayer({
-            ...baseLayer("couleur-inactive-variant", false),
-            ...onlyVariants,
+            ...baseLayer("couleur-inactive-variant-done", false),
+            ...onlyDoneVariants,
+            paint: {
+              "line-dasharray" : [.4, .4],
+              ...widthFromStatus(4, 2.5, 10, 3),
+              ...colorFromStatus(fadedStatusColor),
+            },
+          })
+          .addLayer({
+            ...baseLayer("couleur-inactive-variant-upcoming", false),
+            ...onlyUpcomingVariants,
             paint: {
               "line-dasharray" : [1, 1],
               ...widthFromStatus(4, 2.5, 10, 3),
@@ -159,8 +169,18 @@ export default function Map({ bounds, segments, level, setHash }: Props) {
             },
           })
           .addLayer({
-            ...baseLayer("couleur-active-variant", false),
-            ...onlyVariants,
+            ...baseLayer("couleur-active-variant-done", false),
+            ...onlyDoneVariants,
+            paint: {
+              "line-dasharray" : [.4, .4],
+              ...widthFromStatus(4, 2.5, 10, 3),
+              ...colorFromStatus(statusColor),
+              ...hideWhen("inactive")
+            },
+          })
+          .addLayer({
+            ...baseLayer("couleur-active-variant-upcoming", false),
+            ...onlyUpcomingVariants,
             paint: {
               "line-dasharray" : [1, 1],
               ...widthFromStatus(4, 2.5, 10, 3),

--- a/src/app/style_helpers.ts
+++ b/src/app/style_helpers.ts
@@ -44,12 +44,32 @@ export function baseLayer(id: string, setCap: boolean = true): Layer {
   };
 }
 
-export const onlyDoneVariants: Filter = { filter: ["all", 
- ["get", "variant"],
- ["match", ["get", "status"],[TronçonStatus.Planned, TronçonStatus.Blocked], false, true]] };
-export const onlyUpcomingVariants: Filter = { filter: ["all", 
-  ["get", "variant"],
-  ["match", ["get", "status"],[TronçonStatus.Planned, TronçonStatus.Blocked], true, false]] };
+export const onlyDoneVariants: Filter = {
+  filter: [
+    "all",
+    ["get", "variant"],
+    [
+      "match",
+      ["get", "status"],
+      [TronçonStatus.Planned, TronçonStatus.Blocked],
+      false,
+      true,
+    ],
+  ],
+};
+export const onlyUpcomingVariants: Filter = {
+  filter: [
+    "all",
+    ["get", "variant"],
+    [
+      "match",
+      ["get", "status"],
+      [TronçonStatus.Planned, TronçonStatus.Blocked],
+      true,
+      false,
+    ],
+  ],
+};
 export const exceptedVariants: Filter = { filter: ["!", ["get", "variant"]] };
 
 export function colorFromStatus(colors: ColorMaps): MaplibreColor {

--- a/src/app/style_helpers.ts
+++ b/src/app/style_helpers.ts
@@ -44,7 +44,12 @@ export function baseLayer(id: string, setCap: boolean = true): Layer {
   };
 }
 
-export const onlyVariants: Filter = { filter: ["get", "variant"] };
+export const onlyDoneVariants: Filter = { filter: ["all", 
+ ["get", "variant"],
+ ["match", ["get", "status"],[TronçonStatus.Planned, TronçonStatus.Blocked], false, true]] };
+export const onlyUpcomingVariants: Filter = { filter: ["all", 
+  ["get", "variant"],
+  ["match", ["get", "status"],[TronçonStatus.Planned, TronçonStatus.Blocked], true, false]] };
 export const exceptedVariants: Filter = { filter: ["!", ["get", "variant"]] };
 
 export function colorFromStatus(colors: ColorMaps): MaplibreColor {


### PR DESCRIPTION
refs #41

| | Avant | Après |
|-|-|-|
| Swatches | ![swatches-before](https://github.com/velo-iledefrance/observatoire-vif/assets/139391/de9b3390-7657-409b-b25e-045779986506) | ![swatches-after](https://github.com/velo-iledefrance/observatoire-vif/assets/139391/bb87c915-6f49-4e2d-afe5-07521c387370) |
| Dashes | <img width="916" alt="dash-before" src="https://github.com/velo-iledefrance/observatoire-vif/assets/139391/717ccd2e-68cb-4a13-9884-7c711b9f6f9e"> | <img width="916" alt="dash-after" src="https://github.com/velo-iledefrance/observatoire-vif/assets/139391/f789469e-ac6f-40fc-8512-fa7e68b9fcd3"> |





